### PR TITLE
Handle empty return

### DIFF
--- a/examples/emptyReturn.js
+++ b/examples/emptyReturn.js
@@ -1,0 +1,5 @@
+function emptyReturn () {
+  return
+}
+
+module.exports = emptyReturn

--- a/src/findTailCalls.js
+++ b/src/findTailCalls.js
@@ -1,6 +1,6 @@
 const inFunctionTraversal = {
   ReturnStatement (path) {
-    if (path.node.argument.type === 'CallExpression' && path.node.argument.callee.name === this.functionName) {
+    if (path.node.argument && path.node.argument.type === 'CallExpression' && path.node.argument.callee.name === this.functionName) {
       this.tailCalls.push(path)
     }
   },

--- a/test/emptyReturn.js
+++ b/test/emptyReturn.js
@@ -1,0 +1,10 @@
+const expect = require('chai').expect
+const {withExample} = require('../testUtils')
+
+describe('Transpiling empty return example', function () {
+  it('should not throw', function () {
+    expect(function () {
+      withExample('emptyReturn.js')(function () {}).call({ctx: {}})
+    }).to.not.throw()
+  })
+})


### PR DESCRIPTION
if using`return;`
then in babel-plugin-tailcall-optimization the `path.node.argument` is `null`, thus you get a nice error